### PR TITLE
Switch to hatch build backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+.venv/

--- a/README.md
+++ b/README.md
@@ -4,9 +4,17 @@ To work with proxy you need to provide config in config.yaml and modify mitmprox
 
 **Python 3 required**
 
+Dependencies are managed using [uv](https://github.com/astral-sh/uv).
+
 To install:
 
-``` bash
+```bash
+uv pip install -e .
+```
+
+or simply run:
+
+```bash
 ./setup.sh
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "mitm_mock"
+version = "0.1.0"
+description = "Simple MITM proxy mock"
+readme = "README.md"
+requires-python = ">=3.8"
+dependencies = [
+    "mitmproxy",
+    "pyyaml",
+    "watchdog",
+]

--- a/setup.sh
+++ b/setup.sh
@@ -1,9 +1,7 @@
-#! /bin/bash
+#!/bin/bash
 
-# TODO: use venv?
-pip3 install mitmproxy
-pip3 install pyyaml
-pip3 install watchdog
+uv pip install -e .
 chmod +x mitmMock.sh
+
 echo 'Dependencies installed, please run mitmMock.sh to launch'
-echo 'For more deteils go to README.md' 
+echo 'For more details go to README.md'


### PR DESCRIPTION
## Summary
- manage dependencies in `pyproject.toml`
- install dependencies with uv in `setup.sh`
- document uv usage in README
- ignore local venv files
- switch to `hatchling` build backend

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68401d9789ec8332b538b6c763b9fe2a